### PR TITLE
Suppress non-json output

### DIFF
--- a/phpcs-server/src/linter.ts
+++ b/phpcs-server/src/linter.ts
@@ -278,7 +278,7 @@ export class PhpcsLinter {
 		}
 
 		// Process linting arguments.
-		let lintArgs = [ "--report=json" ];
+		let lintArgs = [ "--report=json", "-q" ];
 		if (settings.standard) {
 			lintArgs.push(`--standard=${settings.standard}`);
 		}


### PR DESCRIPTION
When a standard specifies `<arg value="p"/>` (progress) option linter
breaks since it expects json output, and PHPCS spits out dots for
passing files and 'E' for errors.

Adding `-q` option suppresses progres output.

Maybe related: ikappas/vscode-phpcs#32
See the same issue in PHPCS linter for atom: AtomLinter/linter-phpcs#95