### PR TITLE
[Discussion] [Live Share] Restricting language services to local files

### DIFF
--- a/phpcs/src/extension.ts
+++ b/phpcs/src/extension.ts
@@ -55,7 +55,7 @@ export function activate(context: ExtensionContext) {
 	// Options to control the language client
 	let clientOptions: LanguageClientOptions = {
 		// Register the server for php documents
-		documentSelector: ["php"],
+		documentSelector: [{ language: "php", scheme: "file" }],
 		synchronize: {
 			// Notify the server about file changes to 'ruleset.xml' files contain in the workspace
 			fileEvents: workspace.createFileSystemWatcher("**/ruleset.xml")


### PR DESCRIPTION
In preparation for [Visual Studio Live Share](https://aka.ms/vsls) adding support for "guests" to receive remote language services for PHP, this PR simply updates the current `DocumentSelector` to be limited to local files. This way, when someone has the PHPCS extension installed, and joins a Live Share session (where files use the `vsls:` scheme), their diagnostics will be entirely derived from the remote/host side, which provides a more accurate and project-wide experience (guests in Live Share don't have local file access to the project they're collaborating with).