### PR TITLE
Add continuous integration for vscode-phpcs via Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: node_js
+sudo: false
+
+node_js:
+  - "6.11.2"
+
+install:
+  - npm install
+
+script:
+  - npm run compile

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # vscode-phpcs
 
 [![Maintainers Wanted](https://img.shields.io/badge/maintainers-wanted-red.svg)](https://github.com/pickhardt/maintainers-wanted)
+[![Build Status](https://travis-ci.org/ikappas/vscode-phpcs.svg?branch=develop)](https://travis-ci.org/ikappas/vscode-phpcs)
 [![Current Version](https://vsmarketplacebadge.apphb.com/version/ikappas.phpcs.svg)](https://marketplace.visualstudio.com/items?itemName=ikappas.phpcs)
 [![Install Count](https://vsmarketplacebadge.apphb.com/installs/ikappas.phpcs.svg)](https://marketplace.visualstudio.com/items?itemName=ikappas.phpcs)
 [![Open Issues](https://vsmarketplacebadge.apphb.com/rating/ikappas.phpcs.svg)](https://marketplace.visualstudio.com/items?itemName=ikappas.phpcs)

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "npm-run-all --parallel test:*",
     "test:server": "cd phpcs-server && npm test",
     "test:client": "cd phpcs && npm test",
-    "preinstall": "rimraf node_modules",
+    "preinstall": "npm install rimraf && rimraf node_modules",
     "postinstall": "npm-run-all --parallel postinstall:*",
     "postinstall:server": "cd phpcs-server && npm install",
     "postinstall:client": "cd phpcs && npm install",


### PR DESCRIPTION
I think it is a good idea to integrate some kind of CI to verify compilation as described in the readme. Integrating Travis also allows you to verify if a PR actually compiles.

I've integrated a Travis config-file (from Microsoft/vscode-eslint) and tried it out. I found out that I was missing `rimraf` so I altered the preinstall in the `package.json`. I also added the Travis-CI build badge.

Let me know what you think. If you integrate this, make sure to enable vscode-phpcs in your travis-ci.org account.

See https://travis-ci.org/rikvdh/vscode-phpcs/builds/384413392