### PR TITLE
Fix fileRealPath files lookup in data.files

### DIFF
--- a/phpcs-server/src/linter.ts
+++ b/phpcs-server/src/linter.ts
@@ -209,11 +209,16 @@ export class PhpcsLinter {
 
 		let messages: Array<PhpcsMessage>;
 		if (filePath !== undefined && semver.gte(this.executableVersion, '2.0.0')) {
-			const fileRealPath = extfs.realpathSync(filePath);
-			if (!data.files[fileRealPath]) {
+			const { files, totals } = data;
+
+			if (!totals.errors && !totals.warnings) {
 				return [];
 			}
-			({ messages } = data.files[fileRealPath]);
+
+			let file: any;
+			for (file of Object.entries(files)) {
+				({ messages } = file[1]);
+			};
 		} else {
 			// PHPCS v1 can't associate a filename with STDIN input
 			if (!data.files.STDIN) {
@@ -232,7 +237,7 @@ export class PhpcsLinter {
 
 	private parseData(text: string) {
 		try {
-			return JSON.parse(text) as { files: any };
+			return JSON.parse(text) as { files: any, totals: any };
 		} catch (error) {
 			throw new Error(SR.InvalidJsonStringError);
 		}

--- a/phpcs-server/tsconfig.json
+++ b/phpcs-server/tsconfig.json
@@ -8,7 +8,9 @@
 		"module": "commonjs",
 		"moduleResolution": "node",
 		"sourceMap": true,
-		"lib": [ "es2016" ],
+		"lib": [
+			"es2017"
+		],
 		"outDir": "../phpcs/server"
 	},
 	"exclude": [


### PR DESCRIPTION
- Changed 2016 to 2017 in tsconfig.json, need access to Object.entries
- Fixed issue in phpcs-server/src/linter.ts

In reference to #128