### PR TITLE
Remove rimraf on preinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "test": "npm-run-all --parallel test:*",
     "test:server": "cd phpcs-server && npm test",
     "test:client": "cd phpcs && npm test",
-    "preinstall": "rimraf node_modules",
     "postinstall": "npm-run-all --parallel postinstall:*",
     "postinstall:server": "cd phpcs-server && npm install",
     "postinstall:client": "cd phpcs && npm install",


### PR DESCRIPTION
Build was failing if the rimraf command isn't present in preinstall.