### PR TITLE
Add "extensions" configuration setting

### DIFF
--- a/phpcs-server/src/linter.ts
+++ b/phpcs-server/src/linter.ts
@@ -121,7 +121,7 @@ export class PhpcsLinter {
 		if (standard) {
 			lintArgs.push(`--standard=${standard}`);
 		}
-
+		lintArgs.push(`--extensions=${settings.extensions.join(',')}`);
 		// Check if file should be ignored (Skip for in-memory documents)
 		if (filePath !== undefined && settings.ignorePatterns.length) {
 			if (semver.gte(this.executableVersion, '3.0.0')) {

--- a/phpcs-server/src/settings.ts
+++ b/phpcs-server/src/settings.ts
@@ -10,6 +10,7 @@ export interface PhpcsSettings {
 	executablePath: string | null;
 	composerJsonPath: string | null;
 	standard: string | null;
+	extensions: string[];
 	autoConfigSearch: boolean;
 	showSources: boolean;
 	showWarnings: boolean;

--- a/phpcs/package.json
+++ b/phpcs/package.json
@@ -61,6 +61,19 @@
           "default": null,
           "description": "Optional. The name or path of the coding standard to use. Defaults to the one set in phpcs global config."
         },
+        "phpcs.extensions": {
+          "scope": "resource",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Valid extension to check"
+          },
+          "default": [
+            "php",
+            "inc"
+          ],
+          "description": "An array of valid file extensions that contain PHP code to lint"
+        },
         "phpcs.autoConfigSearch": {
           "scope": "resource",
           "type": "boolean",
@@ -129,5 +142,10 @@
   "dependencies": {
     "vscode": "^1.1.10",
     "vscode-languageclient": "^3.5.0"
+  },
+  "__metadata": {
+    "id": "b0a47156-9132-49a2-bebd-ed16d91b1fa6",
+    "publisherId": "bc9cf215-ec5e-4767-8196-eb73d1ced313",
+    "publisherDisplayName": "Ioannis Kappas"
   }
 }

--- a/phpcs/src/configuration.ts
+++ b/phpcs/src/configuration.ts
@@ -87,6 +87,7 @@ export class PhpcsConfiguration extends Disposable {
 				executablePath: config.get('executablePath'),
 				composerJsonPath: config.get('composerJsonPath'),
 				standard: config.get('standard'),
+				extensions: config.get('extensions'),
 				autoConfigSearch: config.get('autoConfigSearch'),
 				showSources: config.get('showSources'),
 				showWarnings: config.get('showWarnings'),

--- a/phpcs/src/settings.ts
+++ b/phpcs/src/settings.ts
@@ -10,6 +10,7 @@ export interface PhpcsSettings {
 	executablePath: string | null;
 	composerJsonPath: string | null;
 	standard: string | null;
+	extensions: string[];
 	autoConfigSearch: boolean;
 	showSources: boolean;
 	showWarnings: boolean;


### PR DESCRIPTION
Offer this to resolve #159. I'm not 100% sure if I got it right. I was able to hack my installed version of the extension to make this work, and did my best to copy those changes to the source code.

I hope this can be modified to work and accepted, as many people will find this helpful, especially those who work with Drupal that uses a number of different file extensions for PHP code.