### PR TITLE
Use multiline regex to determine phpcs version

### DIFF
--- a/phpcs-server/src/linter.ts
+++ b/phpcs-server/src/linter.ts
@@ -44,7 +44,7 @@ export class PhpcsLinter {
 
 			let result: Buffer = cp.execSync(`"${executablePath}" --version`);
 
-			const versionPattern: RegExp = /^PHP_CodeSniffer version (\d+\.\d+\.\d+)/i;
+			const versionPattern: RegExp = /^PHP_CodeSniffer version (\d+\.\d+\.\d+)/im;
 			const versionMatches = result.toString().match(versionPattern);
 
 			if (versionMatches === null) {


### PR DESCRIPTION
This resolves #150 by changing the regex that checks the version to search on multiple lines.