### PR TITLE
Optimize PHPCS runs

### DIFF
--- a/phpcs/src/status.ts
+++ b/phpcs/src/status.ts
@@ -66,7 +66,7 @@ export class PhpcsStatus {
 			this.timer = new Timer(() => {
 				this.updateStatusText();
 			});
-			this.timer.interval = 100;
+			this.timer.interval = 250;
 		}
 		return this.timer;
 	}


### PR DESCRIPTION
- Only checks PHPCS version every 5 minutes.
- Only split document into lines once instead of for each diagnostic.
- Reduce status bar animation timer frequency.